### PR TITLE
DBZ-6554 Added method to override alter statement field delimiter

### DIFF
--- a/src/main/java/io/debezium/connector/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/debezium/connector/jdbc/dialect/DatabaseDialect.java
@@ -97,6 +97,15 @@ public interface DatabaseDialect {
     String getAlterTableStatement(TableDescriptor table, SinkRecordDescriptor record, Set<String> missingFields);
 
     /**
+     * Gets the field delimeter used when contructing {@code ALTER TABLE} statements.
+     *
+     * @return the field delimeter for alter table SQL statement
+     */
+    default String getAlterTableStatementFieldDelimiter() {
+        return " ";
+    }
+
+    /**
      * Construct a {@code INSERT INTO} statement specific for this dialect.
      *
      * @param table the current relational table model, should not be {@code null}

--- a/src/main/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialect.java
+++ b/src/main/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialect.java
@@ -282,7 +282,7 @@ public class GeneralDatabaseDialect implements DatabaseDialect {
         builder.append("ALTER TABLE ");
         builder.append(getQualifiedTableName(table.getId()));
         builder.append(" ");
-        builder.appendList(" ", missingFields, (name) -> {
+        builder.appendList(getAlterTableStatementFieldDelimiter(), missingFields, (name) -> {
             final FieldDescriptor field = record.getFields().get(name);
             final StringBuilder addColumnSpec = new StringBuilder();
             addColumnSpec.append("ADD ");

--- a/src/main/java/io/debezium/connector/jdbc/dialect/mysql/MySqlDatabaseDialect.java
+++ b/src/main/java/io/debezium/connector/jdbc/dialect/mysql/MySqlDatabaseDialect.java
@@ -82,6 +82,11 @@ public class MySqlDatabaseDialect extends GeneralDatabaseDialect {
     }
 
     @Override
+    public String getAlterTableStatementFieldDelimiter() {
+        return ",";
+    }
+
+    @Override
     public int getMaxVarcharLengthInKey() {
         return 255;
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6554

DBZ-6554 Added method to override alter statement field delimiter, setting it to comma for MySQL dialect