### PR TITLE
DBZ-6857 Do not end Oracle inserts with semicolons

### DIFF
--- a/src/main/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialect.java
+++ b/src/main/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialect.java
@@ -329,7 +329,7 @@ public class GeneralDatabaseDialect implements DatabaseDialect {
 
         builder.appendLists(", ", record.getKeyFieldNames(), record.getNonKeyFieldNames(), (name) -> columnQueryBindingFromField(name, table, record));
 
-        builder.append(");");
+        builder.append(")");
 
         return builder.build();
     }

--- a/src/main/java/io/debezium/connector/jdbc/dialect/sqlserver/SqlServerDatabaseDialect.java
+++ b/src/main/java/io/debezium/connector/jdbc/dialect/sqlserver/SqlServerDatabaseDialect.java
@@ -62,7 +62,7 @@ public class SqlServerDatabaseDialect extends GeneralDatabaseDialect {
         String qualifiedTableName = getQualifiedTableName(table.getId());
         return new StringBuilder()
                 .append("SET IDENTITY_INSERT ").append(qualifiedTableName).append(" ON ;")
-                .append(sqlStatement)
+                .append(sqlStatement).append(";")
                 .append("SET IDENTITY_INSERT ").append(qualifiedTableName).append(" OFF ;")
                 .toString();
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6857

## Summary
The Oracle does not like when INSERT statements are terminated with a semicolon as it causes ORA-00933 errors that the SQL command is not properly ended. This regression was introduced in the SQL Server identity inserts feature and this change adjusts that behavior to avoid the extra semicolon for non-MSSQL.