### PR TITLE
DBZ-6967: Handle bytea target field in in Postgres dialect

### DIFF
--- a/src/main/java/io/debezium/connector/jdbc/dialect/postgres/BytesType.java
+++ b/src/main/java/io/debezium/connector/jdbc/dialect/postgres/BytesType.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.postgres;
+
+import java.nio.ByteBuffer;
+import java.sql.Types;
+
+import org.apache.kafka.connect.data.Schema;
+import org.hibernate.engine.jdbc.Size;
+import org.hibernate.query.Query;
+
+import io.debezium.connector.jdbc.dialect.DatabaseDialect;
+import io.debezium.connector.jdbc.type.AbstractType;
+import io.debezium.connector.jdbc.type.Type;
+import io.debezium.connector.jdbc.util.ByteArrayUtils;
+
+/**
+ * An implementation of {@link Type} for {@code BYTES} column types.
+ *
+ * @author Bertrand Paquet
+ */
+class BytesType extends AbstractType {
+
+    public static final BytesType INSTANCE = new BytesType();
+
+    @Override
+    public String[] getRegistrationKeys() {
+        return new String[]{ "BYTES" };
+    }
+
+    @Override
+    public String getDefaultValueBinding(DatabaseDialect dialect, Schema schema, Object value) {
+        return String.format(dialect.getByteArrayFormat(), ByteArrayUtils.getByteArrayAsHex(value));
+    }
+
+    @Override
+    public String getTypeName(DatabaseDialect dialect, Schema schema, boolean key) {
+        final int columnSize = Integer.parseInt(getSourceColumnSize(schema).orElse("0"));
+        if (columnSize > 0) {
+            return dialect.getTypeName(Types.VARBINARY, Size.length(columnSize));
+        }
+        else if (key) {
+            return dialect.getTypeName(Types.VARBINARY, Size.length(dialect.getMaxVarbinaryLength()));
+        }
+        return dialect.getTypeName(Types.VARBINARY);
+    }
+
+    @Override
+    public int bind(Query<?> query, int index, Schema schema, Object value) {
+        if (value instanceof ByteBuffer) {
+            value = ((ByteBuffer) value).array();
+        }
+        query.setParameter(index, value);
+
+        return 1;
+    }
+}

--- a/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresDatabaseDialect.java
+++ b/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresDatabaseDialect.java
@@ -154,6 +154,7 @@ public class PostgresDatabaseDialect extends GeneralDatabaseDialect {
         registerType(IntervalType.INSTANCE);
         registerType(SerialType.INSTANCE);
         registerType(BitType.INSTANCE);
+        registerType(BytesType.INSTANCE);
         registerType(JsonType.INSTANCE);
         registerType(UuidType.INSTANCE);
         registerType(EnumType.INSTANCE);

--- a/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkColumnTypeMappingIT.java
+++ b/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkColumnTypeMappingIT.java
@@ -5,6 +5,9 @@
  */
 package io.debezium.connector.jdbc.integration.postgres;
 
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
 import java.util.Map;
 
 import org.apache.kafka.connect.data.Schema;
@@ -96,4 +99,44 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
 
         getSink().assertColumn(destinationTable, "data", columnType);
     }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("DBZ-6967")
+    public void testShouldCoerceNioByteBufferTypeToByteArrayColumnType(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.NONE.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+
+        ByteBuffer buffer = ByteBuffer.allocate(3);
+        buffer.put((byte) 1);
+        buffer.put((byte) 2);
+        buffer.put((byte) 3);
+
+        final SinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                Schema.OPTIONAL_BYTES_SCHEMA,
+                buffer);
+
+        final String destinationTable = destinationTableName(createRecord);
+        final String sql = "CREATE TABLE %s (id int not null, data bytea, primary key(id))";
+        getSink().execute(String.format(sql, destinationTable));
+
+        consume(createRecord);
+
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getInt(1)).isEqualTo(1);
+            assertThat(rs.getBytes(2)).isEqualTo(new byte[]{ 1, 2, 3 });
+            return null;
+        });
+    }
+
 }


### PR DESCRIPTION
I'm not sure this is the good way to fix it, but it works :)

With this fix, the connector is able to write into bytea field. Without, it failed with the following stack:
```
[2023-09-25 20:53:19,470] TRACE [main|task-0] Bind field 'bin' at position 6 with type io.debezium.connector.jdbc.type.connect.ConnectBytesType: java.nio.HeapByteBuffer[pos=0 lim=4 cap=4] (io.debezium.connector.jdbc.dialect.GeneralDatabaseDialect:372)
Hibernate: INSERT INTO original_tables.test_cdc (id,updated_at,created_at,name,uuid,bin) VALUES (?,?,?,?,cast(? as uuid),?) ON CONFLICT (id) DO UPDATE SET updated_at=EXCLUDED.updated_at,created_at=EXCLUDED.created_at,name=EXCLUDED.name,uuid=EXCLUDED.uuid,bin=EXCLUDED.bin
[2023-09-25 20:53:19,473] DEBUG [main|task-0] Rewinding topic dbz.cluster-1.data.public.test_cdc offset to 17. (io.debezium.connector.jdbc.JdbcSinkConnectorTask:193)
[2023-09-25 20:53:19,473] ERROR [main|task-0] Failed to process record: Failed to process a sink record (io.debezium.connector.jdbc.JdbcSinkConnectorTask:101)
org.apache.kafka.connect.errors.ConnectException: Failed to process a sink record
	at io.debezium.connector.jdbc.JdbcChangeEventSink.execute(JdbcChangeEventSink.java:72)
	at io.debezium.connector.jdbc.JdbcSinkConnectorTask.put(JdbcSinkConnectorTask.java:93)
	at org.apache.kafka.connect.runtime.WorkerSinkTask.deliverMessages(WorkerSinkTask.java:581)
	at org.apache.kafka.connect.runtime.WorkerSinkTask.poll(WorkerSinkTask.java:333)
	at org.apache.kafka.connect.runtime.WorkerSinkTask.iteration(WorkerSinkTask.java:234)
	at org.apache.kafka.connect.runtime.WorkerSinkTask.execute(WorkerSinkTask.java:203)
	at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:189)
	at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:244)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.NullPointerException: Cannot invoke "org.hibernate.metamodel.mapping.JdbcMapping.getJdbcValueBinder()" because "jdbcMapping" is null
	at org.hibernate.sql.exec.internal.AbstractJdbcParameter.bindParameterValue(AbstractJdbcParameter.java:108)
	at org.hibernate.sql.exec.internal.AbstractJdbcParameter.bindParameterValue(AbstractJdbcParameter.java:98)
	at org.hibernate.sql.exec.internal.StandardJdbcMutationExecutor.execute(StandardJdbcMutationExecutor.java:74)
	at org.hibernate.query.sql.internal.NativeNonSelectQueryPlanImpl.executeUpdate(NativeNonSelectQueryPlanImpl.java:78)
	at org.hibernate.query.sql.internal.NativeQueryImpl.doExecuteUpdate(NativeQueryImpl.java:820)
	at org.hibernate.query.spi.AbstractQuery.executeUpdate(AbstractQuery.java:643)
	at io.debezium.connector.jdbc.JdbcChangeEventSink.writeUpsert(JdbcChangeEventSink.java:258)
	at io.debezium.connector.jdbc.JdbcChangeEventSink.write(JdbcChangeEventSink.java:217)
	at io.debezium.connector.jdbc.JdbcChangeEventSink.execute(JdbcChangeEventSink.java:69)
	... 12 more
```