### PR TITLE
Alter query error

### DIFF
--- a/src/main/java/io/debezium/connector/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/debezium/connector/jdbc/dialect/DatabaseDialect.java
@@ -102,7 +102,7 @@ public interface DatabaseDialect {
      * @return the field delimeter for alter table SQL statement
      */
     default String getAlterTableStatementFieldDelimiter() {
-        return " ";
+        return ",";
     }
 
     /**


### PR DESCRIPTION
delimiter was not used in alter table query