### PR TITLE
DBZ-7752: Handle array for postgres

### DIFF
--- a/src/main/java/io/debezium/connector/jdbc/PreparedStatementQueryBinder.java
+++ b/src/main/java/io/debezium/connector/jdbc/PreparedStatementQueryBinder.java
@@ -26,7 +26,7 @@ public class PreparedStatementQueryBinder implements QueryBinder {
             if (valueBindDescriptor.getTargetSqlType() != null) {
                 if (valueBindDescriptor.getTargetSqlType() == Types.ARRAY) {
                     Collection<Object> collection = (Collection<Object>) valueBindDescriptor.getValue();
-                    Array array = binder.getConnection().createArrayOf(valueBindDescriptor.getSubTypeName(), collection.toArray());
+                    Array array = binder.getConnection().createArrayOf(valueBindDescriptor.getElementTypeName(), collection.toArray());
                     binder.setArray(valueBindDescriptor.getIndex(), array);
                 }
                 else {

--- a/src/main/java/io/debezium/connector/jdbc/PreparedStatementQueryBinder.java
+++ b/src/main/java/io/debezium/connector/jdbc/PreparedStatementQueryBinder.java
@@ -5,8 +5,11 @@
  */
 package io.debezium.connector.jdbc;
 
+import java.sql.Array;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Collection;
 
 public class PreparedStatementQueryBinder implements QueryBinder {
 
@@ -21,7 +24,14 @@ public class PreparedStatementQueryBinder implements QueryBinder {
 
         try {
             if (valueBindDescriptor.getTargetSqlType() != null) {
-                binder.setObject(valueBindDescriptor.getIndex(), valueBindDescriptor.getValue(), valueBindDescriptor.getTargetSqlType());
+                if (valueBindDescriptor.getTargetSqlType() == Types.ARRAY) {
+                    Collection<Object> collection = (Collection<Object>) valueBindDescriptor.getValue();
+                    Array array = binder.getConnection().createArrayOf(valueBindDescriptor.getSubTypeName(), collection.toArray());
+                    binder.setArray(valueBindDescriptor.getIndex(), array);
+                }
+                else {
+                    binder.setObject(valueBindDescriptor.getIndex(), valueBindDescriptor.getValue(), valueBindDescriptor.getTargetSqlType());
+                }
             }
             else {
                 binder.setObject(valueBindDescriptor.getIndex(), valueBindDescriptor.getValue());

--- a/src/main/java/io/debezium/connector/jdbc/ValueBindDescriptor.java
+++ b/src/main/java/io/debezium/connector/jdbc/ValueBindDescriptor.java
@@ -12,27 +12,27 @@ public class ValueBindDescriptor {
 
     private final Integer targetSqlType;
 
-    private final String subTypeName;
+    private final String elementTypeName;
 
     public ValueBindDescriptor(int index, Object value) {
         this.index = index;
         this.value = value;
         this.targetSqlType = null;
-        this.subTypeName = null;
+        this.elementTypeName = null;
     }
 
     public ValueBindDescriptor(int index, Object value, Integer targetSqlType) {
         this.index = index;
         this.value = value;
         this.targetSqlType = targetSqlType;
-        this.subTypeName = null;
+        this.elementTypeName = null;
     }
 
-    public ValueBindDescriptor(int index, Object value, Integer targetSqlType, String subTypeName) {
+    public ValueBindDescriptor(int index, Object value, Integer targetSqlType, String elementTypeName) {
         this.index = index;
         this.value = value;
         this.targetSqlType = targetSqlType;
-        this.subTypeName = subTypeName;
+        this.elementTypeName = elementTypeName;
     }
 
     public int getIndex() {
@@ -47,7 +47,7 @@ public class ValueBindDescriptor {
         return targetSqlType;
     }
 
-    public String getSubTypeName() {
-        return subTypeName;
+    public String getElementTypeName() {
+        return elementTypeName;
     }
 }

--- a/src/main/java/io/debezium/connector/jdbc/ValueBindDescriptor.java
+++ b/src/main/java/io/debezium/connector/jdbc/ValueBindDescriptor.java
@@ -12,16 +12,27 @@ public class ValueBindDescriptor {
 
     private final Integer targetSqlType;
 
+    private final String subTypeName;
+
     public ValueBindDescriptor(int index, Object value) {
         this.index = index;
         this.value = value;
         this.targetSqlType = null;
+        this.subTypeName = null;
     }
 
     public ValueBindDescriptor(int index, Object value, Integer targetSqlType) {
         this.index = index;
         this.value = value;
         this.targetSqlType = targetSqlType;
+        this.subTypeName = null;
+    }
+
+    public ValueBindDescriptor(int index, Object value, Integer targetSqlType, String subTypeName) {
+        this.index = index;
+        this.value = value;
+        this.targetSqlType = targetSqlType;
+        this.subTypeName = subTypeName;
     }
 
     public int getIndex() {
@@ -34,5 +45,9 @@ public class ValueBindDescriptor {
 
     public Integer getTargetSqlType() {
         return targetSqlType;
+    }
+
+    public String getSubTypeName() {
+        return subTypeName;
     }
 }

--- a/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ArrayType.java
+++ b/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ArrayType.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.postgres;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+
+import io.debezium.connector.jdbc.ValueBindDescriptor;
+import io.debezium.connector.jdbc.dialect.DatabaseDialect;
+import io.debezium.connector.jdbc.type.AbstractType;
+import io.debezium.connector.jdbc.type.Type;
+
+/**
+ * An implementation of {@link Type} for {@code ARRAY} column types.
+ *
+ * @author Bertrand Paquet
+ */
+
+public class ArrayType extends AbstractType {
+
+    public static final ArrayType INSTANCE = new ArrayType();
+
+    private String typeName;
+
+    @Override
+    public String[] getRegistrationKeys() {
+        return new String[]{ "ARRAY" };
+    }
+
+    @Override
+    public String getTypeName(DatabaseDialect dialect, Schema schema, boolean key) {
+        Type subType = dialect.getSchemaType(schema.valueSchema());
+        typeName = subType.getTypeName(dialect, schema.valueSchema(), key);
+        return typeName + "[]";
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+        if (value == null) {
+            return Arrays.asList(new ValueBindDescriptor(index, null));
+        }
+        return List.of(new ValueBindDescriptor(index, value, java.sql.Types.ARRAY, typeName));
+    }
+}

--- a/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ArrayType.java
+++ b/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ArrayType.java
@@ -34,8 +34,8 @@ public class ArrayType extends AbstractType {
 
     @Override
     public String getTypeName(DatabaseDialect dialect, Schema schema, boolean key) {
-        Type subType = dialect.getSchemaType(schema.valueSchema());
-        typeName = subType.getTypeName(dialect, schema.valueSchema(), key);
+        Type elementType = dialect.getSchemaType(schema.valueSchema());
+        typeName = elementType.getTypeName(dialect, schema.valueSchema(), key);
         return typeName + "[]";
     }
 

--- a/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresDatabaseDialect.java
+++ b/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresDatabaseDialect.java
@@ -179,6 +179,7 @@ public class PostgresDatabaseDialect extends GeneralDatabaseDialect {
         registerType(XmlType.INSTANCE);
         registerType(LtreeType.INSTANCE);
         registerType(MapToHstoreType.INSTANCE);
+        registerType(ArrayType.INSTANCE);
 
         // Allows binding string-based types if column type propagation is enabled
         registerType(RangeType.INSTANCE);


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-7752

I have a modify the `PreparedStatementQueryBinder`, because we need the `connection` to create array to create the values.

I'm open for comments :) Other alternatives are
* Pass the connection in `getValue` in all cases (can probably be done easily)
* Pass the connection during the `bind` call (bigger refactor)
* Introduce an interface for `ValueBindDescriptor` instead of subclassing it.