### PR TITLE
DBZ-7938: support for multiple array columns of different types

### DIFF
--- a/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ArrayType.java
+++ b/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ArrayType.java
@@ -25,8 +25,6 @@ public class ArrayType extends AbstractType {
 
     public static final ArrayType INSTANCE = new ArrayType();
 
-    private String typeName;
-
     @Override
     public String[] getRegistrationKeys() {
         return new String[]{ "ARRAY" };
@@ -34,9 +32,12 @@ public class ArrayType extends AbstractType {
 
     @Override
     public String getTypeName(DatabaseDialect dialect, Schema schema, boolean key) {
+        return getElementTypeName(dialect, schema, key) + "[]";
+    }
+
+    private String getElementTypeName(DatabaseDialect dialect, Schema schema, boolean key) {
         Type elementType = dialect.getSchemaType(schema.valueSchema());
-        typeName = elementType.getTypeName(dialect, schema.valueSchema(), key);
-        return typeName + "[]";
+        return elementType.getTypeName(dialect, schema.valueSchema(), key);
     }
 
     @Override
@@ -44,6 +45,6 @@ public class ArrayType extends AbstractType {
         if (value == null) {
             return Arrays.asList(new ValueBindDescriptor(index, null));
         }
-        return List.of(new ValueBindDescriptor(index, value, java.sql.Types.ARRAY, typeName));
+        return List.of(new ValueBindDescriptor(index, value, java.sql.Types.ARRAY, getElementTypeName(this.getDialect(), schema, false)));
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-7938
Support for multiple array columns in postgres.
Removing statefulness of ArrayType class.