### PR TITLE
DBZ-7946 Handle partition rebalances

### DIFF
--- a/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorTask.java
+++ b/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorTask.java
@@ -123,6 +123,15 @@ public class JdbcSinkConnectorTask extends SinkTask {
     }
 
     @Override
+    public void open(Collection<TopicPartition> partitions) {
+        if (LOGGER.isTraceEnabled()) {
+            for (TopicPartition partition : partitions) {
+                LOGGER.trace("Requested open TopicPartition request for '{}'", partition);
+            }
+        }
+    }
+
+    @Override
     public void close(Collection<TopicPartition> partitions) {
         for (TopicPartition partition : partitions) {
             if (offsets.containsKey(partition)) {


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-7946

### Details
There are two things at play here to support partition rebalance. The first is to handle the close function call to remove the entry from the offset map that is maintained by the connector when a partition rebalance happens.

The second is to address the fact that Kafka 3.6+ changed the SinkRecord API and in order to match the close TopicPartition list with the managed offsets, we need to always make sure we use the originalXXXX methods that were added in Kafka 3.6, falling back to the old behavior for Kafka 3.5 or before.