### PR TITLE
DBZ-7969 Bump Hibernate dependency to 6.4.8.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <version.assembly.plugin>3.5.0</version.assembly.plugin>
 
         <!-- Other artifact versions -->
-        <version.hibernate>6.2.18.Final</version.hibernate>
+        <version.hibernate>6.4.8.Final</version.hibernate>
         <version.c3p0>0.9.5.5</version.c3p0>
         <version.assertjdb>2.0.2</version.assertjdb>
 

--- a/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/jdbc/JdbcSinkConnectorConfig.java
@@ -70,7 +70,6 @@ public class JdbcSinkConnectorConfig {
     public static final String FIELD_INCLUDE_LIST = "field.include.list";
     public static final String FIELD_EXCLUDE_LIST = "field.exclude.list";
     public static final String USE_REDUCTION_BUFFER = "use.reduction.buffer";
-    public static final String COLUMN_TYPE_RESOLUTION_MODE = "column.type.resolution.mode";
 
     // todo add support for the ValueConverter contract
 
@@ -320,16 +319,6 @@ public class JdbcSinkConnectorConfig {
             .withDescription(
                     "A reduction buffer consolidates the execution of SQL statements by primary key to reduce the SQL load on the target database. When set to false (the default), each incoming event is applied as a logical SQL change. When set to true, incoming events that refer to the same row will be reduced to a single logical change based on the most recent row state.");
 
-    public static final Field COLUMN_TYPE_RESOLUTION_MODE_FIELD = Field.create(COLUMN_TYPE_RESOLUTION_MODE)
-            .withDisplayName("Specifies how a column's type is resolved")
-            .withEnum(ColumnTypeResolutionMode.class, ColumnTypeResolutionMode.LEGACY)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR, 2))
-            .withWidth(ConfigDef.Width.SHORT)
-            .withImportance(ConfigDef.Importance.MEDIUM)
-            .withDescription("Controls how the column type is resolved when no length is specified in the event metadata. " +
-                    "legacy: Uses the legacy behavior where non-length character and binary types prefer CLOB, TEXT, LONGTEXT, BLOB types, " +
-                    "improved: Uses an improved behavior to prefer character-based texts like VARCHAR but with the dialect's maximum length instead of CLOB, TEXT, or LONGTEXT types.");
-
     protected static final ConfigDefinition CONFIG_DEFINITION = ConfigDefinition.editor()
             .connector(
                     CONNECTION_URL_FIELD,
@@ -355,8 +344,7 @@ public class JdbcSinkConnectorConfig {
                     SQLSERVER_IDENTITY_INSERT_FIELD,
                     BATCH_SIZE_FIELD,
                     FIELD_INCLUDE_LIST_FIELD,
-                    FIELD_EXCLUDE_LIST_FIELD,
-                    COLUMN_TYPE_RESOLUTION_MODE_FIELD)
+                    FIELD_EXCLUDE_LIST_FIELD)
             .create();
 
     /**
@@ -509,39 +497,7 @@ public class JdbcSinkConnectorConfig {
         public String getValue() {
             return mode;
         }
-    }
 
-    public enum ColumnTypeResolutionMode implements EnumeratedValue {
-        /**
-         * The legacy column type resolution that is based on Debezium 2.x behavior.
-         */
-        LEGACY("legacy"),
-
-        /**
-         * An improved mode that favors using maximum length character-based data types over the
-         * use of large object types such as CLOB, TEXT, LONGTEXT, etc.
-         */
-        IMPROVED("improved");
-
-        private String mode;
-
-        ColumnTypeResolutionMode(String mode) {
-            this.mode = mode;
-        }
-
-        public static ColumnTypeResolutionMode parse(String value) {
-            for (ColumnTypeResolutionMode option : ColumnTypeResolutionMode.values()) {
-                if (option.getValue().equalsIgnoreCase(value)) {
-                    return option;
-                }
-            }
-            return ColumnTypeResolutionMode.LEGACY;
-        }
-
-        @Override
-        public String getValue() {
-            return mode;
-        }
     }
 
     private final Configuration config;
@@ -560,10 +516,11 @@ public class JdbcSinkConnectorConfig {
     private final String databaseTimezone;
     private final String postgresPostgisSchema;
     private final boolean sqlServerIdentityInsert;
-    private final long batchSize;
-    private final boolean useReductionBuffer;
-    private final ColumnTypeResolutionMode columnTypeResolutionMode;
     private FieldNameFilter fieldsFilter;
+
+    private final long batchSize;
+
+    private final boolean useReductionBuffer;
 
     public JdbcSinkConnectorConfig(Map<String, String> props) {
         config = Configuration.from(props);
@@ -583,7 +540,6 @@ public class JdbcSinkConnectorConfig {
         this.sqlServerIdentityInsert = config.getBoolean(SQLSERVER_IDENTITY_INSERT_FIELD);
         this.batchSize = config.getLong(BATCH_SIZE_FIELD);
         this.useReductionBuffer = config.getBoolean(USE_REDUCTION_BUFFER_FIELD);
-        this.columnTypeResolutionMode = ColumnTypeResolutionMode.parse(config.getString(COLUMN_TYPE_RESOLUTION_MODE_FIELD));
 
         String fieldExcludeList = config.getString(FIELD_EXCLUDE_LIST);
         String fieldIncludeList = config.getString(FIELD_INCLUDE_LIST);
@@ -683,10 +639,6 @@ public class JdbcSinkConnectorConfig {
 
     public String getPostgresPostgisSchema() {
         return postgresPostgisSchema;
-    }
-
-    public ColumnTypeResolutionMode getColumnTypeResolutionMode() {
-        return columnTypeResolutionMode;
     }
 
     /** makes {@link org.hibernate.cfg.Configuration} from connector config

--- a/src/main/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialect.java
+++ b/src/main/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialect.java
@@ -516,6 +516,8 @@ public class GeneralDatabaseDialect implements DatabaseDialect {
                 case Types.VARCHAR:
                 case Types.NVARCHAR:
                     return getTypeName(Types.LONGVARCHAR);
+                case Types.VARBINARY:
+                    return getTypeName(Types.LONGVARBINARY);
                 default:
                     return ddlTypeRegistry.getTypeName(jdbcType, dialect);
             }
@@ -526,6 +528,8 @@ public class GeneralDatabaseDialect implements DatabaseDialect {
                     return getTypeName(jdbcType, dialect.getMaxVarcharLength());
                 case Types.NVARCHAR:
                     return getTypeName(jdbcType, dialect.getMaxNVarcharLength());
+                case Types.VARBINARY:
+                    return getTypeName(jdbcType, dialect.getMaxVarbinaryLength());
                 default:
                     return ddlTypeRegistry.getTypeName(jdbcType, dialect);
             }

--- a/src/main/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialect.java
+++ b/src/main/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialect.java
@@ -5,8 +5,6 @@
  */
 package io.debezium.connector.jdbc.dialect;
 
-import static io.debezium.connector.jdbc.JdbcSinkConnectorConfig.ColumnTypeResolutionMode;
-
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
@@ -511,29 +509,15 @@ public class GeneralDatabaseDialect implements DatabaseDialect {
         // for us as we were relying on Hibernate for column type resolution, and now column types
         // are being resolved differently. This code aims to retain the Debezium 2.x resolution
         // functionality.
-        if (ColumnTypeResolutionMode.LEGACY.equals(connectorConfig.getColumnTypeResolutionMode())) {
-            switch (jdbcType) {
-                case Types.VARCHAR:
-                    return getTypeName(Types.LONGVARCHAR);
-                case Types.NVARCHAR:
-                    return getTypeName(Types.LONGNVARCHAR);
-                case Types.VARBINARY:
-                    return getTypeName(Types.LONGVARBINARY);
-                default:
-                    return ddlTypeRegistry.getTypeName(jdbcType, dialect);
-            }
-        }
-        else {
-            switch (jdbcType) {
-                case Types.VARCHAR:
-                    return getTypeName(jdbcType, dialect.getMaxVarcharLength());
-                case Types.NVARCHAR:
-                    return getTypeName(jdbcType, dialect.getMaxNVarcharLength());
-                case Types.VARBINARY:
-                    return getTypeName(jdbcType, dialect.getMaxVarbinaryLength());
-                default:
-                    return ddlTypeRegistry.getTypeName(jdbcType, dialect);
-            }
+        switch (jdbcType) {
+            case Types.VARCHAR:
+                return getTypeName(Types.LONGVARCHAR);
+            case Types.NVARCHAR:
+                return getTypeName(Types.LONGNVARCHAR);
+            case Types.VARBINARY:
+                return getTypeName(Types.LONGVARBINARY);
+            default:
+                return ddlTypeRegistry.getTypeName(jdbcType, dialect);
         }
     }
 

--- a/src/main/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialect.java
+++ b/src/main/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialect.java
@@ -514,8 +514,9 @@ public class GeneralDatabaseDialect implements DatabaseDialect {
         if (ColumnTypeResolutionMode.LEGACY.equals(connectorConfig.getColumnTypeResolutionMode())) {
             switch (jdbcType) {
                 case Types.VARCHAR:
-                case Types.NVARCHAR:
                     return getTypeName(Types.LONGVARCHAR);
+                case Types.NVARCHAR:
+                    return getTypeName(Types.LONGNVARCHAR);
                 case Types.VARBINARY:
                     return getTypeName(Types.LONGVARBINARY);
                 default:


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-7969

### Changes

This PR introduces a new `column.type.resolution.mode` property, with two configurable options:
* legacy
* improved

The default (legacy) will retain the current Debezium 2.x behavior, where STRING-based fields will be serialized using the dialect's extended length data types: `CLOB`, `NCLOB`, `LONGTEXT`, `TEXT`, etc. 

The new option (improved) is designed to favor non-LOB or non-TEXT column types and rather will pick the maximum length based VARCHAR column types for the target database.  I'd like to consider setting this new improved mode as the default in Debezium 3.

- ~~[ ] Document new `column.type.resolution.mode` if we agree to keep it.~~
- ~~[ ] Update test suite to include tests for the _improved_ resolution mode.~~
- [x] Verify changes fixes problems with column resolution (waits on CI).

UPDATE:
Based on discussions on Zulip, we're going to forego the configuration property, introducing it in Debezium 3.0 and only address the broken functionality in this PR's scope.